### PR TITLE
fix: add assert! calls around matches! calls in unit tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -313,22 +313,22 @@ mod tests {
         let engine = RuleEngine::new(rules, false, false);
 
         // Test allow rule
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::GET, "https://github.com/api"),
             Action::Allow
-        );
+        ));
 
         // Test deny rule
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::POST, "https://telemetry.example.com"),
             Action::Deny
-        );
+        ));
 
         // Test default deny
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::GET, "https://example.com"),
             Action::Deny
-        );
+        ));
     }
 
     #[test]
@@ -338,10 +338,10 @@ mod tests {
         let engine = RuleEngine::new(rules, true, false);
 
         // In dry-run mode, everything should be allowed
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::GET, "https://example.com"),
             Action::Allow
-        );
+        ));
     }
 
     #[test]
@@ -351,9 +351,9 @@ mod tests {
         let engine = RuleEngine::new(rules, false, true);
 
         // In log-only mode, everything should be allowed
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::POST, "https://example.com"),
             Action::Allow
-        );
+        ));
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -141,22 +141,22 @@ mod tests {
         let engine = RuleEngine::new(rules, false, false);
 
         // Test allow rule
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::GET, "https://github.com/api"),
             Action::Allow
-        );
+        ));
 
         // Test deny rule
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::POST, "https://telemetry.example.com"),
             Action::Deny
-        );
+        ));
 
         // Test default deny
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::GET, "https://example.com"),
             Action::Deny
-        );
+        ));
     }
 
     #[test]
@@ -171,16 +171,16 @@ mod tests {
         let engine = RuleEngine::new(rules, false, false);
 
         // GET should be allowed
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::GET, "https://api.example.com/data"),
             Action::Allow
-        );
+        ));
 
         // POST should be denied (doesn't match method filter)
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::POST, "https://api.example.com/data"),
             Action::Deny
-        );
+        ));
     }
 
     #[test]
@@ -190,10 +190,10 @@ mod tests {
         let engine = RuleEngine::new(rules, true, false);
 
         // In dry-run mode, everything should be allowed
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::GET, "https://example.com"),
             Action::Allow
-        );
+        ));
     }
 
     #[test]
@@ -203,9 +203,9 @@ mod tests {
         let engine = RuleEngine::new(rules, false, true);
 
         // In log-only mode, everything should be allowed
-        matches!(
+        assert!(matches!(
             engine.evaluate(Method::POST, "https://example.com"),
             Action::Allow
-        );
+        ));
     }
 }


### PR DESCRIPTION
The `matches!` macro in rust simply returns a boolean, we need to add asserts for these tests to work as intended.
Edit: If you're on nightly, there's also https://doc.rust-lang.org/std/assert_matches/macro.assert_matches.html. 