### PR TITLE
macos lacks timeout, so don't run timeout test on macos

### DIFF
--- a/tests/weak_integration.rs
+++ b/tests/weak_integration.rs
@@ -47,6 +47,10 @@ fn test_weak_mode_blocks_http_correctly() {
     }
 }
 
+// MacOS does not have `timeout` by default. Other options here could be `gtimeout`
+// if coreutils is install or a simple perl script which mac has by default (these suggestions
+// are courtesy of claude).
+#[cfg(not(target_os = "macos"))]
 #[test]
 fn test_weak_mode_timeout_works() {
     // Test that the timeout mechanism works correctly


### PR DESCRIPTION
Just a test tweak because `timeout` isn't installed on mac by default