### PR TITLE
add camino to save boilerplate down the line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "camino"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0"
+
+[[package]]
 name = "cc"
 version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +694,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "bytes",
+ "camino",
  "chrono",
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 dirs = "6.0.0"
 hyper-rustls = "0.27.7"
 tls-parser = "0.12.2"
+camino = "1.1.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 nix = { version = "0.27", features = ["user"] }

--- a/src/jail/macos/mod.rs
+++ b/src/jail/macos/mod.rs
@@ -2,7 +2,7 @@ use super::{Jail, JailConfig};
 use anyhow::{Context, Result};
 use libc;
 use std::fs;
-use std::path::Path;
+use camino::Utf8Path;
 use std::process::{Command, ExitStatus};
 use tracing::{debug, info, warn};
 
@@ -282,7 +282,7 @@ anchor "{}"
         }
 
         // Clean up temp file
-        if Path::new(&self.pf_rules_path).exists() {
+        if Utf8Path::new(&self.pf_rules_path).exists() {
             fs::remove_file(&self.pf_rules_path).context("Failed to remove PF rules file")?;
         }
 

--- a/src/proxy_tls.rs
+++ b/src/proxy_tls.rs
@@ -561,7 +561,7 @@ mod tests {
 
     async fn create_test_cert_manager() -> Arc<CertificateManager> {
         let temp_dir = TempDir::new().unwrap();
-        let cert_manager = CertificateManager::with_config_dir(Some(temp_dir.path().to_path_buf()))
+        let cert_manager = CertificateManager::with_config_dir(Some(temp_dir.path().to_path_buf().try_into().expect("tempdir library provided non utf8 tmp dir")))
             .expect("Failed to create test certificate manager");
         Arc::new(cert_manager)
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -87,7 +87,7 @@ impl HttpjailCommand {
 
             // Use askpass for macOS if available
             #[cfg(target_os = "macos")]
-            if std::path::Path::new("askpass_macos.sh").exists() {
+            if camino::Utf8Path::new("askpass_macos.sh").exists() {
                 sudo_cmd.env(
                     "SUDO_ASKPASS",
                     format!(


### PR DESCRIPTION
Adds the camino crate for drop in Path and PathBuf replacements that are guaranteed to be valid utf8. In the long run there's generally less boilerplate to deal with when your paths all implement `Display`.