### PR TITLE
feat: add request log flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,9 @@ sudo ./target/release/httpjail --allow "httpbin\.org" -- curl http://httpbin.org
 # Test with method-specific rules
 sudo ./target/release/httpjail --allow-get ".*" -- curl -X POST http://httpbin.org/post
 
-# Test log-only mode
-sudo ./target/release/httpjail --log-only -- curl http://example.com
+# Test request logging
+sudo ./target/release/httpjail --request-log requests.log -r "allow: .*" -- curl http://example.com
+# Log format: "<timestamp> <+/-> <METHOD> <URL>" (+ = allowed, - = blocked)
 ```
 
 ### Test Organization

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ cargo install httpjail
 # Allow only requests to github.com
 httpjail -r "allow: github\.com" -r "deny: .*" -- claude
 
-# Monitor all requests without blocking
-httpjail --log-only -- npm install
+# Log requests to a file
+httpjail --request-log requests.log -r "allow: .*" -- npm install
+# Log format: "<timestamp> <+/-> <METHOD> <URL>" (+ = allowed, - = blocked)
 
 # Block specific domains
 httpjail -r "deny: telemetry\..*" -r "allow: .*" -- ./my-app
@@ -215,7 +216,7 @@ OPTIONS:
                                  Methods: get, post, put, delete, head, options, connect, trace, patch
     -c, --config <FILE>          Use configuration file
     --dry-run                    Log actions without blocking
-    --log-only                   Monitor without filtering
+    --request-log <FILE>         Append requests to log file (+ for allowed, - for blocked)
     --no-tls-intercept          Disable HTTPS interception
     --interactive               Interactive approval mode
     --weak                      Use weak mode (env vars only, no system isolation)

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -458,7 +458,7 @@ mod tests {
             Rule::new(Action::Deny, r".*").unwrap(),
         ];
 
-        let rule_engine = RuleEngine::new(rules, false, false);
+        let rule_engine = RuleEngine::new(rules, false, None);
         let proxy = ProxyServer::new(Some(8080), Some(8443), rule_engine, None);
 
         assert_eq!(proxy.http_port, Some(8080));
@@ -469,7 +469,7 @@ mod tests {
     async fn test_proxy_server_auto_port() {
         let rules = vec![Rule::new(Action::Allow, r".*").unwrap()];
 
-        let rule_engine = RuleEngine::new(rules, false, false);
+        let rule_engine = RuleEngine::new(rules, false, None);
         let mut proxy = ProxyServer::new(None, None, rule_engine, None);
 
         let (http_port, https_port) = proxy.start().await.unwrap();

--- a/src/proxy_tls.rs
+++ b/src/proxy_tls.rs
@@ -593,7 +593,7 @@ mod tests {
                 Rule::new(Action::Deny, r".*").unwrap(),
             ]
         };
-        Arc::new(RuleEngine::new(rules, false, false))
+        Arc::new(RuleEngine::new(rules, false, None))
     }
 
     /// Create a TLS client config that trusts any certificate (for testing)

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,7 +1,11 @@
 use anyhow::Result;
+use chrono::{SecondsFormat, Utc};
 use hyper::Method;
 use regex::Regex;
 use std::collections::HashSet;
+use std::fs::File;
+use std::io::Write;
+use std::sync::{Arc, Mutex};
 use tracing::{info, warn};
 
 #[derive(Debug, Clone)]
@@ -49,26 +53,25 @@ impl Rule {
 pub struct RuleEngine {
     pub rules: Vec<Rule>,
     pub dry_run: bool,
-    pub log_only: bool,
+    pub request_log: Option<Arc<Mutex<File>>>,
 }
 
 impl RuleEngine {
-    pub fn new(rules: Vec<Rule>, dry_run: bool, log_only: bool) -> Self {
+    pub fn new(rules: Vec<Rule>, dry_run: bool, request_log: Option<Arc<Mutex<File>>>) -> Self {
         RuleEngine {
             rules,
             dry_run,
-            log_only,
+            request_log,
         }
     }
 
     pub fn evaluate(&self, method: Method, url: &str) -> Action {
-        if self.log_only {
-            info!("Request: {} {}", method, url);
-            return Action::Allow;
-        }
+        let mut action = Action::Deny;
+        let mut matched = false;
 
         for rule in &self.rules {
             if rule.matches(method.clone(), url) {
+                matched = true;
                 match &rule.action {
                     Action::Allow => {
                         info!(
@@ -77,9 +80,7 @@ impl RuleEngine {
                             url,
                             rule.pattern.as_str()
                         );
-                        if !self.dry_run {
-                            return Action::Allow;
-                        }
+                        action = Action::Allow;
                     }
                     Action::Deny => {
                         warn!(
@@ -88,27 +89,41 @@ impl RuleEngine {
                             url,
                             rule.pattern.as_str()
                         );
-                        if !self.dry_run {
-                            return Action::Deny;
-                        }
+                        action = Action::Deny;
                     }
+                }
+                if !self.dry_run {
+                    break;
                 }
             }
         }
 
-        // Default deny if no rules match
-        warn!("DENY: {} {} (no matching rules)", method, url);
-        if self.dry_run {
-            Action::Allow
-        } else {
-            Action::Deny
+        if !matched {
+            warn!("DENY: {} {} (no matching rules)", method, url);
+            action = Action::Deny;
         }
+
+        if let Some(log) = &self.request_log
+            && let Ok(mut file) = log.lock()
+        {
+            let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+            let status = match &action {
+                Action::Allow => '+',
+                Action::Deny => '-',
+            };
+            if let Err(e) = writeln!(file, "{} {} {} {}", timestamp, status, method, url) {
+                warn!("Failed to write to request log: {}", e);
+            }
+        }
+
+        if self.dry_run { Action::Allow } else { action }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_rule_matching() {
@@ -138,7 +153,7 @@ mod tests {
             Rule::new(Action::Deny, r".*").unwrap(),
         ];
 
-        let engine = RuleEngine::new(rules, false, false);
+        let engine = RuleEngine::new(rules, false, None);
 
         // Test allow rule
         assert!(matches!(
@@ -168,7 +183,7 @@ mod tests {
             Rule::new(Action::Deny, r".*").unwrap(),
         ];
 
-        let engine = RuleEngine::new(rules, false, false);
+        let engine = RuleEngine::new(rules, false, None);
 
         // GET should be allowed
         assert!(matches!(
@@ -187,7 +202,7 @@ mod tests {
     fn test_dry_run_mode() {
         let rules = vec![Rule::new(Action::Deny, r".*").unwrap()];
 
-        let engine = RuleEngine::new(rules, true, false);
+        let engine = RuleEngine::new(rules, true, None);
 
         // In dry-run mode, everything should be allowed
         assert!(matches!(
@@ -197,15 +212,38 @@ mod tests {
     }
 
     #[test]
-    fn test_log_only_mode() {
+    fn test_request_logging() {
+        use std::fs::OpenOptions;
+
+        let rules = vec![Rule::new(Action::Allow, r".*").unwrap()];
+        let log_file = tempfile::NamedTempFile::new().unwrap();
+        let file = OpenOptions::new()
+            .append(true)
+            .open(log_file.path())
+            .unwrap();
+        let engine = RuleEngine::new(rules, false, Some(Arc::new(Mutex::new(file))));
+
+        engine.evaluate(Method::GET, "https://example.com");
+
+        let contents = std::fs::read_to_string(log_file.path()).unwrap();
+        assert!(contents.contains("+ GET https://example.com"));
+    }
+
+    #[test]
+    fn test_request_logging_denied() {
+        use std::fs::OpenOptions;
+
         let rules = vec![Rule::new(Action::Deny, r".*").unwrap()];
+        let log_file = tempfile::NamedTempFile::new().unwrap();
+        let file = OpenOptions::new()
+            .append(true)
+            .open(log_file.path())
+            .unwrap();
+        let engine = RuleEngine::new(rules, false, Some(Arc::new(Mutex::new(file))));
 
-        let engine = RuleEngine::new(rules, false, true);
+        engine.evaluate(Method::GET, "https://blocked.com");
 
-        // In log-only mode, everything should be allowed
-        assert!(matches!(
-            engine.evaluate(Method::POST, "https://example.com"),
-            Action::Allow
-        ));
+        let contents = std::fs::read_to_string(log_file.path()).unwrap();
+        assert!(contents.contains("- GET https://blocked.com"));
     }
 }

--- a/tests/platform_test_macro.rs
+++ b/tests/platform_test_macro.rs
@@ -28,8 +28,8 @@ macro_rules! platform_tests {
 
         #[test]
         #[::serial_test::serial]
-        fn test_jail_log_only_mode() {
-            system_integration::test_jail_log_only_mode::<$platform>();
+        fn test_jail_request_log() {
+            system_integration::test_jail_request_log::<$platform>();
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- replace `--log-only` with `--request-log` to append requests to a log file
- record each request with RFC3339 timestamps, allow/deny marker, method, and URL
- document log format and test both allowed and denied request logging

## Testing
- `cargo test` *(fails: Failed to execute ip netns add)*
- `cargo clippy --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c1b36d2cb883298bab42d5f09ff211