### PR TITLE
Remove dry-run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,6 @@ httpjail --config rules.txt -- ./my-application
 ### Advanced Options
 
 ```bash
-# Dry run - log what would be blocked without blocking
-httpjail --dry-run --config rules.txt -- ./app
-
 # Verbose logging
 httpjail -vvv --allow ".*" -- curl https://example.com
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,6 @@ struct Args {
     #[arg(short = 'c', long = "config", value_name = "FILE")]
     config: Option<String>,
 
-    /// Log actions without blocking
-    #[arg(long = "dry-run")]
-    dry_run: bool,
-
     /// Monitor without filtering
     #[arg(long = "log-only")]
     log_only: bool,
@@ -308,7 +304,7 @@ async fn main() -> Result<()> {
 
     // Build rules from command line arguments
     let rules = build_rules(&args)?;
-    let rule_engine = RuleEngine::new(rules, args.dry_run, args.log_only);
+    let rule_engine = RuleEngine::new(rules, args.log_only);
 
     // Get ports from env vars (optional)
     let http_port = std::env::var("HTTPJAIL_HTTP_BIND")
@@ -468,7 +464,7 @@ mod tests {
             Rule::new(Action::Deny, r".*").unwrap(),
         ];
 
-        let engine = RuleEngine::new(rules, false, false);
+        let engine = RuleEngine::new(rules, false);
 
         // Test allow rule
         assert!(matches!(
@@ -490,23 +486,10 @@ mod tests {
     }
 
     #[test]
-    fn test_dry_run_mode() {
-        let rules = vec![Rule::new(Action::Deny, r".*").unwrap()];
-
-        let engine = RuleEngine::new(rules, true, false);
-
-        // In dry-run mode, everything should be allowed
-        assert!(matches!(
-            engine.evaluate(Method::GET, "https://example.com"),
-            Action::Allow
-        ));
-    }
-
-    #[test]
     fn test_log_only_mode() {
         let rules = vec![Rule::new(Action::Deny, r".*").unwrap()];
 
-        let engine = RuleEngine::new(rules, false, true);
+        let engine = RuleEngine::new(rules, true);
 
         // In log-only mode, everything should be allowed
         assert!(matches!(
@@ -530,7 +513,6 @@ mod tests {
         let args = Args {
             rules: vec![],
             config: Some(file.path().to_str().unwrap().to_string()),
-            dry_run: false,
             log_only: false,
             no_tls_intercept: false,
             interactive: false,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -458,7 +458,7 @@ mod tests {
             Rule::new(Action::Deny, r".*").unwrap(),
         ];
 
-        let rule_engine = RuleEngine::new(rules, false, false);
+        let rule_engine = RuleEngine::new(rules, false);
         let proxy = ProxyServer::new(Some(8080), Some(8443), rule_engine, None);
 
         assert_eq!(proxy.http_port, Some(8080));
@@ -469,7 +469,7 @@ mod tests {
     async fn test_proxy_server_auto_port() {
         let rules = vec![Rule::new(Action::Allow, r".*").unwrap()];
 
-        let rule_engine = RuleEngine::new(rules, false, false);
+        let rule_engine = RuleEngine::new(rules, false);
         let mut proxy = ProxyServer::new(None, None, rule_engine, None);
 
         let (http_port, https_port) = proxy.start().await.unwrap();

--- a/src/proxy_tls.rs
+++ b/src/proxy_tls.rs
@@ -593,7 +593,7 @@ mod tests {
                 Rule::new(Action::Deny, r".*").unwrap(),
             ]
         };
-        Arc::new(RuleEngine::new(rules, false, false))
+        Arc::new(RuleEngine::new(rules, false))
     }
 
     /// Create a TLS client config that trusts any certificate (for testing)

--- a/tests/platform_test_macro.rs
+++ b/tests/platform_test_macro.rs
@@ -34,12 +34,6 @@ macro_rules! platform_tests {
 
         #[test]
         #[::serial_test::serial]
-        fn test_jail_dry_run_mode() {
-            system_integration::test_jail_dry_run_mode::<$platform>();
-        }
-
-        #[test]
-        #[::serial_test::serial]
         fn test_jail_requires_command() {
             system_integration::test_jail_requires_command::<$platform>();
         }

--- a/tests/system_integration.rs
+++ b/tests/system_integration.rs
@@ -224,34 +224,6 @@ pub fn test_jail_log_only_mode<P: JailTestPlatform>() {
     );
 }
 
-/// Test dry-run mode
-pub fn test_jail_dry_run_mode<P: JailTestPlatform>() {
-    P::require_privileges();
-
-    let mut cmd = httpjail_cmd();
-    cmd.arg("--dry-run")
-        .arg("-r")
-        .arg("deny: .*") // Deny everything
-        .arg("--");
-    curl_http_status_args(&mut cmd, "http://ifconfig.me");
-
-    let output = cmd.output().expect("Failed to execute httpjail");
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if !stderr.is_empty() {
-        eprintln!("[{}] stderr: {}", P::platform_name(), stderr);
-    }
-
-    // In dry-run mode, even deny rules should not block
-    assert_eq!(
-        stdout.trim(),
-        "200",
-        "Request should be allowed in dry-run mode"
-    );
-    assert!(output.status.success());
-}
-
 /// Test that jail requires a command
 pub fn test_jail_requires_command<P: JailTestPlatform>() {
     // This test doesn't require root


### PR DESCRIPTION
## Summary
- drop `--dry-run` flag and related code
- update rule engine and docs to reflect removal

## Testing
- `cargo test` *(fails: Failed to execute ip netns add)*
- `cargo clippy --all-targets -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_68c1b480440c83299db80e269fc2c973