### PR TITLE
Add --server mode for standalone proxy operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cargo install httpjail
 ## MVP TODO
 
 - [ ] Update README to be more reflective of AI agent restrictions
-- [ ] Add a `--server` mode that runs the proxy server but doesn't execute the command
+- [x] Add a `--server` mode that runs the proxy server but doesn't execute the command
 - [ ] Expand test cases to include WebSockets
 
 ## Quick Start
@@ -43,6 +43,10 @@ httpjail -r "allow-get: api\.github\.com" -r "deny: .*" -- git pull
 
 # Use config file for complex rules
 httpjail --config rules.txt -- python script.py
+
+# Run as standalone proxy server (no command execution)
+httpjail --server -r "allow: .*"
+# Then set HTTP_PROXY=http://localhost:8080 HTTPS_PROXY=http://localhost:8443 in your application
 ```
 
 ## Architecture Overview
@@ -171,6 +175,11 @@ httpjail --dry-run --config rules.txt -- ./app
 
 # Verbose logging
 httpjail -vvv -r "allow: .*" -- curl https://example.com
+
+# Server mode - run as standalone proxy without executing commands
+httpjail --server -r "allow: github\.com" -r "deny: .*"
+# Proxy listens on localhost:8080 (HTTP) and localhost:8443 (HTTPS)
+# Configure applications to use these proxy endpoints
 
 ```
 


### PR DESCRIPTION
## Summary
- Implements `--server` flag to run httpjail as a standalone proxy server
- Allows httpjail to act as a persistent HTTP/HTTPS proxy service without executing commands
- Useful for scenarios where multiple applications need to connect to a running proxy

## Changes
- Added `--server` CLI flag with appropriate conflict checks (conflicts with `--cleanup`, `--weak`, `--timeout`)
- Implemented server mode logic that runs the proxy indefinitely until interrupted
- Added graceful shutdown handling with Ctrl+C
- Updated README with usage examples and documentation
- Marked feature as completed in TODO list

## Test plan
- [x] Built project successfully with `cargo build --release`
- [x] Tested server mode starts and listens on ports
- [x] Verified graceful shutdown with Ctrl+C
- [x] Passed `cargo fmt` formatting check
- [x] Passed `cargo clippy --all-targets -- -D warnings` linting

## Usage
```bash
# Run as standalone proxy server
httpjail --server -r "allow: github\.com" -r "deny: .*"

# Server listens on localhost:8080 (HTTP) and localhost:8443 (HTTPS)
# Configure applications to use: 
# HTTP_PROXY=http://localhost:8080 
# HTTPS_PROXY=http://localhost:8443
```

🤖 Generated with [Claude Code](https://claude.ai/code)