### PR TITLE
feat: default deny rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ cargo install httpjail
 - 🌐 **HTTP/HTTPS interception** - Transparent proxy with TLS certificate injection
 - 🎯 **Regex-based filtering** - Flexible allow/deny rules with regex patterns
 - 📝 **Request logging** - Monitor and log all HTTP/HTTPS requests
+- ⛔ **Default deny** - Requests are blocked unless explicitly allowed
 - 🖥️ **Cross-platform** - Native support for Linux and macOS
 - ⚡ **Zero configuration** - Works out of the box with sensible defaults
 
@@ -27,6 +28,8 @@ cargo install httpjail
 - [ ] Expand test cases to include WebSockets
 
 ## Quick Start
+
+> By default, httpjail denies all network requests. Add `allow:` rules to permit traffic.
 
 ```bash
 # Allow only requests to github.com

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -182,4 +182,14 @@ mod tests {
             Action::Allow
         ));
     }
+
+    #[test]
+    fn test_default_deny_with_no_rules() {
+        let engine = RuleEngine::new(vec![], false);
+
+        assert!(matches!(
+            engine.evaluate(Method::GET, "https://example.com"),
+            Action::Deny
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- rely on rule engine to deny requests when no rules match instead of inserting a default deny rule
- log when no rules are provided and test default denial with an empty rule set

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` *(fails: Failed to execute ip netns add)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d31fd61c832997ee43371d8456fa