### PR TITLE
Use shared Rust cache across Linux workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,8 @@ jobs:
       
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}
       
       - name: Verify version matches tag
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -78,6 +80,11 @@ jobs:
           if [ -d /home/ci/.cargo/git ]; then
             sudo chown -R ci:ci /home/ci/.cargo/git || true
           fi
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}
 
       - name: Setup Rust environment and install nextest
         run: |
@@ -132,6 +139,8 @@ jobs:
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -160,6 +169,8 @@ jobs:
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}
 
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
@@ -176,6 +187,11 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}
 
       - name: Check formatting
         run: cargo fmt -- --check


### PR DESCRIPTION
## Summary
- share a single `Swatinem/rust-cache` across Linux jobs by setting `shared-key`
- enable cache sharing for self-hosted and fmt jobs
- apply the same cache key in publish workflow

## Testing
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d7a3fbf88329bb7979a8c0ce83bb