### PR TITLE
docs: clarify script shell usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ httpjail --script ./check_request.sh -- curl https://github.com
 httpjail --script '[ "$HTTPJAIL_HOST" = "github.com" ] && exit 0 || exit 1' -- git pull
 ```
 
+If `--script` has spaces, it's run through `$SHELL` (default `/bin/sh`); otherwise it's executed directly.
+
 **Environment variables provided to the script:**
 
 - `HTTPJAIL_URL` - Full URL being requested


### PR DESCRIPTION
## Summary
- document how the `--script` flag chooses a shell

## Testing
- `cargo fmt`
- `cargo test` *(fails: Failed to execute ip netns add)*

------
https://chatgpt.com/codex/tasks/task_e_68c2469bd2d083299b27aad21475197e