### PR TITLE
fix: optimize Linux privilege dropping with setpriv and remove redundant env exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,10 @@ The CI workspace is located at `/home/ci/actions-runner/_work/httpjail/httpjail`
 # SCP files to/from CI-1
 ./scripts/ci-scp.sh src/ /tmp/httpjail-docker-run/     # Upload
 ./scripts/ci-scp.sh root@ci-1:/path/to/file ./         # Download
+
+# Wait for PR checks to pass or fail
+./scripts/wait-pr-checks.sh 47               # Monitor PR #47
+./scripts/wait-pr-checks.sh 47 coder/httpjail # Specify repo explicitly
 ```
 
 ### Manual Testing on CI

--- a/scripts/wait-pr-checks.sh
+++ b/scripts/wait-pr-checks.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# wait-pr-checks.sh - Poll GitHub Actions status for a PR and exit on first failure or when all pass
+#
+# Usage: ./scripts/wait-pr-checks.sh <pr-number> [repo]
+#   pr-number: The PR number to check
+#   repo: Optional repository in format owner/repo (defaults to coder/httpjail)
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - A check failed
+#   2 - Invalid arguments
+#
+# Requires: gh, jq
+
+set -euo pipefail
+
+# Parse arguments
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <pr-number> [repo]" >&2
+    echo "Example: $0 47" >&2
+    echo "Example: $0 47 coder/httpjail" >&2
+    exit 2
+fi
+
+PR_NUMBER="$1"
+REPO="${2:-coder/httpjail}"
+
+# Check for required tools
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed" >&2
+    exit 2
+fi
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "Monitoring PR #${PR_NUMBER} in ${REPO}..."
+echo "Polling every second. Press Ctrl+C to stop."
+echo ""
+
+# Track the last status to avoid duplicate output
+last_status=""
+
+while true; do
+    # Get check status as JSON
+    if ! json_output=$(gh pr checks "${PR_NUMBER}" --repo "${REPO}" --json name,status,conclusion,detailsUrl 2>/dev/null); then
+        echo -e "${YELLOW}Waiting for checks to start...${NC}"
+        sleep 1
+        continue
+    fi
+    
+    # Parse JSON to get counts
+    pending_count=$(echo "$json_output" | jq '[.[] | select(.status == "IN_PROGRESS" or .status == "QUEUED")] | length')
+    failed_count=$(echo "$json_output" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED")] | length')
+    passed_count=$(echo "$json_output" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+    total_count=$(echo "$json_output" | jq 'length')
+    
+    # Build status string
+    current_status="✓ ${passed_count} passed | ⏳ ${pending_count} pending | ✗ ${failed_count} failed"
+    
+    # Only print if status changed
+    if [ "$current_status" != "$last_status" ]; then
+        echo -ne "\r\033[K${current_status}"
+        last_status="$current_status"
+    fi
+    
+    # Check for failures
+    if [ $failed_count -gt 0 ]; then
+        echo -e "\n\n${RED}❌ The following check(s) failed:${NC}"
+        echo "$json_output" | jq -r '.[] | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED") | "  - \(.name)"'
+        echo -e "\nView details at: https://github.com/${REPO}/pull/${PR_NUMBER}/checks"
+        exit 1
+    fi
+    
+    # Check if all passed
+    if [ $total_count -gt 0 ] && [ $pending_count -eq 0 ] && [ $failed_count -eq 0 ]; then
+        echo -e "\n\n${GREEN}✅ All ${passed_count} checks passed!${NC}"
+        echo -e "PR #${PR_NUMBER} is ready to merge."
+        exit 0
+    fi
+    
+    sleep 1
+done


### PR DESCRIPTION
## Summary
- Removed redundant environment variable exports in Linux jail command execution  
- Replaced `su` → `runuser` → **`setpriv`** for optimal privilege dropping
- Environment variables are now only set via Command::env()
- Added `scripts/wait-pr-checks.sh` for CI monitoring

## Background
Previously, environment variables were being set twice:
1. Via explicit 'export' commands in the shell command string
2. Via Command::env() method on the process

This led to verbose debug output like:
```
Executing command: CURL_CA_BUNDLE="/root/.config/httpjail/ca-cert.pem" ... "sh" "-c" "export SSL_CERT_FILE='/root/.config/httpjail/ca-cert.pem'; export SSL_CERT_DIR='/root/.config/httpjail'; ..."
```

## Changes
1. **Removed redundant exports**: Environment variables are now only set via Command::env()
2. **Evolution of privilege dropping**:
   - ~~`su` with shell wrapper~~ (original)
   - ~~`runuser` with --preserve-environment~~ (first improvement)
   - **`setpriv` with --reuid/--regid** (final solution)

## Why setpriv?
After analysis of `runuser` vs `setpriv`:
- **No PAM**: setpriv doesn't use PAM, making it lighter and simpler
- **Direct execve()**: No additional layers, just a wrapper around execve()
- **Recommended by runuser docs**: "For non-PAM sessions, use setpriv"
- **Better fit**: We're just dropping privileges, not creating login sessions

Implementation uses:
- `--reuid=<uid>` and `--regid=<gid>` from SUDO_UID/SUDO_GID
- `--init-groups` to properly initialize supplementary groups

## Test plan
- [x] Tests pass on Linux (ci-1)
- [x] Builds successfully with `cargo build --profile fast`
- [x] All 20 Linux integration tests pass
- [x] Specific privilege dropping test passes with setpriv

🤖 Generated with [Claude Code](https://claude.ai/code)