### PR TITLE
fix: prevent DNS exfiltration in strong jails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,7 @@ dependencies = [
  "rcgen",
  "rustls",
  "serial_test",
+ "simple-dns",
  "socket2 0.5.10",
  "tempfile",
  "tls-parser",
@@ -1875,6 +1876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple-dns"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c80e565e7dcc4f1ef247e2f395550d4cf7d777746d5988e7e4e3156b71077fc"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ filetime = "0.2"
 ctrlc = "3.4"
 url = "2.5"
 v8 = "129"
+simple-dns = "0.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,32 @@ httpjail includes built-in protection against DNS exfiltration attacks. In isola
 
 This approach blocks DNS tunneling while maintaining full HTTP/HTTPS functionality through transparent proxy redirection.
 
+```mermaid
+sequenceDiagram
+    participant J as Jailed Process
+    participant S as Jail Server
+    participant I as Internet
+    
+    Note over J,I: DNS Exfiltration Attempt
+    J->>S: DNS Query: secret-data.attacker.com
+    S-->>J: Response: 6.6.6.6 (dummy)
+    Note over S,I: ❌ Query never reaches Internet
+    
+    Note over J,I: Normal HTTP Request Flow
+    J->>S: HTTP GET http://example.com
+    Note over S: Rule evaluation: allowed?
+    alt Rule allows (r.host === 'example.com')
+        S->>I: Forward HTTP request
+        I-->>S: HTTP response
+        S-->>J: Forward response
+    else Rule denies
+        S-->>J: 403 Forbidden
+        Note over S,I: ❌ Request blocked
+    end
+```
+
+The diagram shows how DNS queries are always answered locally with a dummy IP (6.6.6.6), preventing any data from reaching external DNS servers. Meanwhile, HTTP/HTTPS traffic is evaluated by rules and only forwarded to the Internet if explicitly allowed.
+
 ## Prerequisites
 
 ### Linux

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -1,0 +1,205 @@
+use anyhow::{Context, Result};
+use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+use tracing::{debug, error, info, warn};
+
+const DNS_PORT: u16 = 53;
+const DUMMY_IPV4: Ipv4Addr = Ipv4Addr::new(6, 6, 6, 6);
+const MAX_DNS_PACKET_SIZE: usize = 512;
+
+pub struct DummyDnsServer {
+    socket: Option<UdpSocket>,
+    shutdown: Arc<AtomicBool>,
+    thread_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl DummyDnsServer {
+    pub fn new() -> Self {
+        Self {
+            socket: None,
+            shutdown: Arc::new(AtomicBool::new(false)),
+            thread_handle: None,
+        }
+    }
+
+    pub fn start(&mut self, bind_addr: &str) -> Result<()> {
+        let socket = UdpSocket::bind(bind_addr)
+            .with_context(|| format!("Failed to bind DNS server to {}", bind_addr))?;
+
+        socket.set_read_timeout(Some(Duration::from_millis(100)))?;
+
+        info!("Starting dummy DNS server on {}", bind_addr);
+
+        let socket_clone = socket.try_clone()?;
+        let shutdown_clone = self.shutdown.clone();
+
+        let thread_handle = thread::spawn(move || {
+            if let Err(e) = run_dns_server(socket_clone, shutdown_clone) {
+                error!("DNS server error: {}", e);
+            }
+        });
+
+        self.socket = Some(socket);
+        self.thread_handle = Some(thread_handle);
+
+        Ok(())
+    }
+
+    pub fn stop(&mut self) {
+        debug!("Stopping dummy DNS server");
+        self.shutdown.store(true, Ordering::Relaxed);
+
+        if let Some(handle) = self.thread_handle.take() {
+            let _ = handle.join();
+        }
+
+        self.socket = None;
+    }
+}
+
+impl Drop for DummyDnsServer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn run_dns_server(socket: UdpSocket, shutdown: Arc<AtomicBool>) -> Result<()> {
+    let mut buf = [0u8; MAX_DNS_PACKET_SIZE];
+
+    while !shutdown.load(Ordering::Relaxed) {
+        match socket.recv_from(&mut buf) {
+            Ok((size, src)) => {
+                debug!("Received DNS query from {}: {} bytes", src, size);
+
+                if size >= 12 {
+                    if let Ok(response) = build_dummy_response(&buf[..size]) {
+                        if let Err(e) = socket.send_to(&response, src) {
+                            warn!("Failed to send DNS response to {}: {}", src, e);
+                        } else {
+                            debug!("Sent dummy DNS response to {}", src);
+                        }
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                continue;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+                continue;
+            }
+            Err(e) => {
+                if !shutdown.load(Ordering::Relaxed) {
+                    error!("DNS server receive error: {}", e);
+                }
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn build_dummy_response(query: &[u8]) -> Result<Vec<u8>> {
+    if query.len() < 12 {
+        anyhow::bail!("DNS query too short");
+    }
+
+    let mut response = Vec::with_capacity(512);
+
+    response.extend_from_slice(&query[0..2]);
+
+    let mut flags = ((query[2] as u16) << 8) | (query[3] as u16);
+    flags |= 0x8000;
+    flags &= !0x7800;
+    flags &= !0x000F;
+
+    response.push((flags >> 8) as u8);
+    response.push((flags & 0xFF) as u8);
+
+    let qdcount = ((query[4] as u16) << 8) | (query[5] as u16);
+    response.extend_from_slice(&query[4..6]);
+
+    response.push(0);
+    response.push(1);
+
+    response.push(0);
+    response.push(0);
+    response.push(0);
+    response.push(0);
+
+    let mut pos = 12;
+    let query_end = find_query_end(query, pos)?;
+    response.extend_from_slice(&query[12..query_end]);
+
+    response.push(0xC0);
+    response.push(0x0C);
+
+    response.push(0);
+    response.push(1);
+
+    response.push(0);
+    response.push(1);
+
+    response.push(0);
+    response.push(0);
+    response.push(0);
+    response.push(60);
+
+    response.push(0);
+    response.push(4);
+
+    response.extend_from_slice(&DUMMY_IPV4.octets());
+
+    Ok(response)
+}
+
+fn find_query_end(packet: &[u8], start: usize) -> Result<usize> {
+    let mut pos = start;
+
+    while pos < packet.len() {
+        let len = packet[pos] as usize;
+        if len == 0 {
+            pos += 1;
+            break;
+        }
+        if len >= 0xC0 {
+            pos += 2;
+            break;
+        }
+        pos += len + 1;
+    }
+
+    if pos + 4 > packet.len() {
+        anyhow::bail!("Malformed DNS query");
+    }
+
+    Ok(pos + 4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dns_response_builder() {
+        let query = vec![
+            0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, b'g',
+            b'o', b'o', b'g', b'l', b'e', 0x03, b'c', b'o', b'm', 0x00, 0x00, 0x01, 0x00, 0x01,
+        ];
+
+        let response = build_dummy_response(&query).unwrap();
+
+        assert_eq!(response[0..2], query[0..2]);
+
+        assert_eq!(response[2] & 0x80, 0x80);
+
+        let answer_count = ((response[6] as u16) << 8) | (response[7] as u16);
+        assert_eq!(answer_count, 1);
+
+        let response_ip = &response[response.len() - 4..];
+        assert_eq!(response_ip, &[6, 6, 6, 6]);
+    }
+}

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -173,7 +173,7 @@ mod tests {
         // Check that the answer contains our dummy IP
         if let Some(answer) = response.answers.first() {
             if let RData::A(ip) = &answer.rdata {
-                assert_eq!(ip.address, DUMMY_IPV4);
+                assert_eq!(Ipv4Addr::from(ip.address), DUMMY_IPV4);
             } else {
                 panic!("Expected A record in response");
             }

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::collapsible_if)]
+
 use anyhow::{Context, Result};
 use std::net::{Ipv4Addr, UdpSocket};
 use std::sync::Arc;

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -6,7 +6,6 @@ use std::thread;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
-const DNS_PORT: u16 = 53;
 const DUMMY_IPV4: Ipv4Addr = Ipv4Addr::new(6, 6, 6, 6);
 const MAX_DNS_PACKET_SIZE: usize = 512;
 

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -173,10 +173,7 @@ mod tests {
         // Check that the answer contains our dummy IP
         if let Some(answer) = response.answers.first() {
             if let RData::A(ip) = &answer.rdata {
-                assert_eq!(ip.a, 6);
-                assert_eq!(ip.b, 6);
-                assert_eq!(ip.c, 6);
-                assert_eq!(ip.d, 6);
+                assert_eq!(ip.address, DUMMY_IPV4);
             } else {
                 panic!("Expected A record in response");
             }

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
+use std::net::{Ipv4Addr, UdpSocket};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::collapsible_if)]
-
 use anyhow::{Context, Result};
 use std::net::{Ipv4Addr, UdpSocket};
 use std::sync::Arc;
@@ -67,6 +65,7 @@ impl Drop for DummyDnsServer {
     }
 }
 
+#[allow(clippy::collapsible_if)]
 fn run_dns_server(socket: UdpSocket, shutdown: Arc<AtomicBool>) -> Result<()> {
     let mut buf = [0u8; MAX_DNS_PACKET_SIZE];
 

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -119,7 +119,7 @@ fn build_dummy_response(query: &[u8]) -> Result<Vec<u8>> {
     response.push((flags >> 8) as u8);
     response.push((flags & 0xFF) as u8);
 
-    let qdcount = ((query[4] as u16) << 8) | (query[5] as u16);
+    // Copy question count from query
     response.extend_from_slice(&query[4..6]);
 
     response.push(0);
@@ -130,8 +130,7 @@ fn build_dummy_response(query: &[u8]) -> Result<Vec<u8>> {
     response.push(0);
     response.push(0);
 
-    let mut pos = 12;
-    let query_end = find_query_end(query, pos)?;
+    let query_end = find_query_end(query, 12)?;
     response.extend_from_slice(&query[12..query_end]);
 
     response.push(0xC0);

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -117,12 +117,12 @@ fn build_dummy_response(query: Packet<'_>) -> Result<Vec<u8>> {
     response.set_flags(PacketFlag::RESPONSE | PacketFlag::RECURSION_AVAILABLE);
 
     // Copy all questions from the query to the response
-    for question in query.questions() {
+    for question in &query.questions {
         response.questions.push(question.clone());
     }
 
     // For each question, add a dummy A record response
-    for question in query.questions() {
+    for question in &query.questions {
         // Only respond to A record queries (TYPE 1)
         // But we'll respond to all queries with an A record anyway
         // to prevent any DNS exfiltration attempts

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -74,13 +74,13 @@ fn run_dns_server(socket: UdpSocket, shutdown: Arc<AtomicBool>) -> Result<()> {
             Ok((size, src)) => {
                 debug!("Received DNS query from {}: {} bytes", src, size);
 
-                if size >= 12 {
-                    if let Ok(response) = build_dummy_response(&buf[..size]) {
-                        if let Err(e) = socket.send_to(&response, src) {
-                            warn!("Failed to send DNS response to {}: {}", src, e);
-                        } else {
-                            debug!("Sent dummy DNS response to {}", src);
-                        }
+                if size >= 12
+                    && let Ok(response) = build_dummy_response(&buf[..size])
+                {
+                    if let Err(e) = socket.send_to(&response, src) {
+                        warn!("Failed to send DNS response to {}: {}", src, e);
+                    } else {
+                        debug!("Sent dummy DNS response to {}", src);
                     }
                 }
             }

--- a/src/jail/linux/dns.rs
+++ b/src/jail/linux/dns.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use simple_dns::rdata::RData;
-use simple_dns::{CLASS, Packet, PacketFlag, ResourceRecord, TYPE};
+use simple_dns::{CLASS, Packet, PacketFlag, ResourceRecord};
 use std::net::{Ipv4Addr, UdpSocket};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -144,7 +144,7 @@ fn build_dummy_response(query: Packet<'_>) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use simple_dns::{Name, Question};
+    use simple_dns::{Name, Question, TYPE};
 
     #[test]
     fn test_dns_response_builder() {

--- a/src/jail/linux/docker.rs
+++ b/src/jail/linux/docker.rs
@@ -284,6 +284,7 @@ impl DockerLinux {
         &["-e", "-v", "-p", "--name", "--entrypoint", "-w", "--user"];
 
     /// Build the docker command with isolated network
+    #[allow(clippy::collapsible_if)]
     fn build_docker_command(
         &self,
         docker_args: &[String],

--- a/src/jail/linux/mod.rs
+++ b/src/jail/linux/mod.rs
@@ -585,37 +585,7 @@ nameserver 127.0.0.1\n",
 
         info!("Starting dummy DNS server in namespace {}", namespace_name);
 
-        // Create the DNS server
-        let mut dns_server = DummyDnsServer::new();
-
-        // We need to start the DNS server inside the namespace
-        // The server will bind to 127.0.0.1:53 inside the namespace
-        let ns_path = format!("/var/run/netns/{}", namespace_name);
-
-        // Use a thread to run the DNS server in the namespace context
-        let dns_server_arc = Arc::new(Mutex::new(dns_server));
-        let dns_server_clone = Arc::clone(&dns_server_arc);
-        let ns_name_clone = namespace_name.clone();
-
-        // Start DNS server in a separate thread that enters the namespace
-        std::thread::spawn(move || {
-            // Enter the network namespace
-            let output = Command::new("ip")
-                .args([
-                    "netns",
-                    "exec",
-                    &ns_name_clone,
-                    "sh",
-                    "-c",
-                    "exec 3<>/dev/tcp/127.0.0.1/53 2>/dev/null || echo 'port available'",
-                ])
-                .output();
-
-            // The DNS server will actually run in the host, but we'll redirect traffic to it
-            // For now, we'll start it on the host and use nftables to redirect
-        });
-
-        // Actually, let's simplify - start the DNS server on the host side
+        // Start the DNS server on the host side
         // and use nftables to redirect DNS traffic from the namespace
         let mut dns_server = DummyDnsServer::new();
 

--- a/src/jail/linux/mod.rs
+++ b/src/jail/linux/mod.rs
@@ -221,6 +221,9 @@ impl LinuxJail {
         let commands = vec![
             // Bring up loopback
             vec!["ip", "link", "set", "lo", "up"],
+            // Enable route_localnet to allow DNAT on loopback (needed for DNS redirection)
+            vec!["sysctl", "-w", "net.ipv4.conf.all.route_localnet=1"],
+            vec!["sysctl", "-w", "net.ipv4.conf.lo.route_localnet=1"],
             // Configure veth interface with IP
             vec!["ip", "addr", "add", &self.guest_cidr, "dev", &veth_ns],
             vec!["ip", "link", "set", &veth_ns, "up"],
@@ -231,6 +234,7 @@ impl LinuxJail {
         for cmd_args in commands {
             let mut cmd = Command::new("ip");
             cmd.args(["netns", "exec", &namespace_name]);
+            // First element is the actual command to run in the namespace
             cmd.args(&cmd_args);
 
             let output = cmd.output().context(format!(

--- a/src/jail/linux/mod.rs
+++ b/src/jail/linux/mod.rs
@@ -464,6 +464,7 @@ nameserver {}\n",
     }
 
     /// Ensure DNS works in the namespace by copying resolv.conf if needed
+    #[allow(clippy::collapsible_if)]
     fn ensure_namespace_dns(&self) -> Result<()> {
         let namespace_name = self.namespace_name();
 

--- a/src/jail/linux/mod.rs
+++ b/src/jail/linux/mod.rs
@@ -819,6 +819,7 @@ impl Clone for LinuxJail {
             veth_pair: None,
             namespace_config: None,
             nftables: None,
+            dns_server: None,
             host_ip: self.host_ip,
             host_cidr: self.host_cidr.clone(),
             guest_cidr: self.guest_cidr.clone(),

--- a/src/jail/linux/nftables.rs
+++ b/src/jail/linux/nftables.rs
@@ -163,6 +163,10 @@ table ip {} {{
         # Explicitly block all other UDP (e.g., QUIC on 443)
         # This must come AFTER allowing DNS traffic
         ip protocol udp drop
+        
+        # Explicitly block all other TCP traffic
+        # This must come AFTER allowing HTTP/HTTPS traffic
+        ip protocol tcp drop
     }}
 }}
 "#,

--- a/src/jail/linux/nftables.rs
+++ b/src/jail/linux/nftables.rs
@@ -51,7 +51,6 @@ table ip {} {{
         type filter hook input priority -100; policy accept;
         iifname "{}" tcp dport {{ {}, {} }} accept comment "httpjail_{} proxy"
         iifname "{}" udp dport 53 accept comment "httpjail_{} dns"
-        iifname "{}" tcp dport 53 accept comment "httpjail_{} dns tcp"
         iifname "{}" accept comment "httpjail_{} all"
     }}
     
@@ -73,8 +72,6 @@ table ip {} {{
             veth_host,
             http_port,
             https_port,
-            jail_id,
-            veth_host,
             jail_id,
             veth_host,
             jail_id,
@@ -157,9 +154,8 @@ table ip {} {{
         # Always allow established/related traffic
         ct state established,related accept
 
-        # Allow DNS traffic directly to the host (no DNAT needed)
+        # Allow DNS traffic directly to the host (UDP only)
         ip daddr {} udp dport 53 accept
-        ip daddr {} tcp dport 53 accept
 
         # Allow traffic to the host proxy ports after DNAT
         ip daddr {} tcp dport {{ {}, {} }} accept
@@ -175,8 +171,7 @@ table ip {} {{
             http_port, // HTTP redirect
             host_ip,
             https_port, // HTTPS redirect
-            host_ip,    // Allow DNS to host IP
-            host_ip,    // Allow DNS to host IP
+            host_ip,    // Allow DNS to host IP (UDP only)
             host_ip,
             http_port,
             https_port // Allow HTTP/HTTPS to host

--- a/src/jail/linux/nftables.rs
+++ b/src/jail/linux/nftables.rs
@@ -30,55 +30,42 @@ impl NFTable {
         // Generate the ruleset for host-side NAT, forwarding, and input acceptance
         let ruleset = format!(
             r#"
-table ip {} {{
+table ip {table_name} {{
     chain prerouting {{
         type filter hook prerouting priority -150; policy accept;
-        iifname "{}" accept comment "httpjail_{} prerouting"
+        iifname "{veth_host}" accept comment "httpjail_{jail_id} prerouting"
     }}
     
     chain postrouting {{
         type nat hook postrouting priority 100; policy accept;
-        ip saddr {} masquerade comment "httpjail_{}"
+        ip saddr {subnet_cidr} masquerade comment "httpjail_{jail_id}"
     }}
     
     chain forward {{
         type filter hook forward priority -100; policy accept;
-        ip saddr {} accept comment "httpjail_{} out"
-        ip daddr {} accept comment "httpjail_{} in"
+        ip saddr {subnet_cidr} accept comment "httpjail_{jail_id} out"
+        ip daddr {subnet_cidr} accept comment "httpjail_{jail_id} in"
     }}
     
     chain input {{
         type filter hook input priority -100; policy accept;
-        iifname "{}" tcp dport {{ {}, {} }} accept comment "httpjail_{} proxy"
-        iifname "{}" udp dport 53 accept comment "httpjail_{} dns"
-        iifname "{}" accept comment "httpjail_{} all"
+        iifname "{veth_host}" tcp dport {{ {http_port}, {https_port} }} accept comment "httpjail_{jail_id} proxy"
+        iifname "{veth_host}" udp dport 53 accept comment "httpjail_{jail_id} dns"
+        iifname "{veth_host}" accept comment "httpjail_{jail_id} all"
     }}
     
     chain output {{
         type filter hook output priority -100; policy accept;
-        oifname "{}" accept comment "httpjail_{} out"
+        oifname "{veth_host}" accept comment "httpjail_{jail_id} out"
     }}
 }}
 "#,
-            table_name,
-            veth_host,
-            jail_id,
-            subnet_cidr,
-            jail_id,
-            subnet_cidr,
-            jail_id,
-            subnet_cidr,
-            jail_id,
-            veth_host,
-            http_port,
-            https_port,
-            jail_id,
-            veth_host,
-            jail_id,
-            veth_host,
-            jail_id,
-            veth_host,
-            jail_id
+            table_name = table_name,
+            veth_host = veth_host,
+            jail_id = jail_id,
+            subnet_cidr = subnet_cidr,
+            http_port = http_port,
+            https_port = https_port,
         );
 
         debug!("Creating nftables table: {}", table_name);
@@ -135,16 +122,16 @@ table ip {} {{
         // Generate the ruleset for namespace-side DNAT + FILTER
         let ruleset = format!(
             r#"
-table ip {} {{
+table ip {table_name} {{
     # NAT output chain: redirect HTTP/HTTPS to host proxy
     chain output {{
         type nat hook output priority -100; policy accept;
 
         # Redirect HTTP to proxy running on host
-        tcp dport 80 dnat to {}:{}
+        tcp dport 80 dnat to {host_ip}:{http_port}
 
         # Redirect HTTPS to proxy running on host
-        tcp dport 443 dnat to {}:{}
+        tcp dport 443 dnat to {host_ip}:{https_port}
     }}
 
     # FILTER output chain: block non-HTTP/HTTPS egress
@@ -155,10 +142,10 @@ table ip {} {{
         ct state established,related accept
 
         # Allow DNS traffic directly to the host (UDP only)
-        ip daddr {} udp dport 53 accept
+        ip daddr {host_ip} udp dport 53 accept
 
         # Allow traffic to the host proxy ports after DNAT
-        ip daddr {} tcp dport {{ {}, {} }} accept
+        ip daddr {host_ip} tcp dport {{ {http_port}, {https_port} }} accept
 
         # Explicitly block all other UDP (e.g., QUIC on 443)
         # This must come AFTER allowing DNS traffic
@@ -170,15 +157,10 @@ table ip {} {{
     }}
 }}
 "#,
-            table_name,
-            host_ip,
-            http_port, // HTTP redirect
-            host_ip,
-            https_port, // HTTPS redirect
-            host_ip,    // Allow DNS to host IP (UDP only)
-            host_ip,
-            http_port,
-            https_port // Allow HTTP/HTTPS to host
+            table_name = table_name,
+            host_ip = host_ip,
+            http_port = http_port,
+            https_port = https_port,
         );
 
         debug!(

--- a/src/jail/linux/nftables.rs
+++ b/src/jail/linux/nftables.rs
@@ -175,11 +175,12 @@ table ip {} {{
         ip daddr {} udp dport {} accept
         ip daddr {} tcp dport {} accept
 
-        # Explicitly block all other UDP (e.g., QUIC on 443)
-        ip protocol udp drop
-
         # Allow traffic to the host proxy ports after DNAT
         ip daddr {} tcp dport {{ {}, {} }} accept
+
+        # Explicitly block all other UDP (e.g., QUIC on 443)
+        # This must come AFTER allowing DNS traffic
+        ip protocol udp drop
     }}
 }}
 "#,

--- a/src/jail/linux/nftables.rs
+++ b/src/jail/linux/nftables.rs
@@ -126,16 +126,6 @@ table ip {} {{
     }
 
     /// Create namespace-side nftables rules for traffic redirection and egress filtering
-    pub fn new_namespace_table(
-        namespace: &str,
-        host_ip: &str,
-        http_port: u16,
-        https_port: u16,
-    ) -> Result<Self> {
-        Self::new_namespace_table_with_dns(namespace, host_ip, http_port, https_port, 5353)
-    }
-
-    /// Create namespace-side nftables rules for traffic redirection and egress filtering
     pub fn new_namespace_table_with_dns(
         namespace: &str,
         host_ip: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::collapsible_if)]
+
 pub mod dangerous_verifier;
 pub mod jail;
 pub mod macos_keychain;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,11 @@ struct RunArgs {
     #[arg(long = "sh", value_name = "PROG")]
     sh: Option<String>,
 
-    /// Use JavaScript (V8) for evaluating requests
-    /// The JavaScript code receives global variables:
-    ///   url, method, host, scheme, path
-    /// Should return true to allow the request, false to block it
-    /// Example: --js "return host === 'github.com' && method === 'GET'"
+    /// Use JavaScript (V8) expression for evaluating requests
+    /// The JavaScript expression receives an object 'r' with properties:
+    ///   r.url, r.method, r.host, r.scheme, r.path
+    /// Should evaluate to true to allow the request, false to block it
+    /// Example: --js "r.host === 'github.com' && r.method === 'GET'"
     #[arg(
         long = "js",
         value_name = "CODE",

--- a/tests/platform_test_macro.rs
+++ b/tests/platform_test_macro.rs
@@ -85,5 +85,11 @@ macro_rules! platform_tests {
         fn test_jail_dns_resolution() {
             system_integration::test_jail_dns_resolution::<$platform>();
         }
+
+        #[test]
+        #[::serial_test::serial]
+        fn test_dns_exfiltration_prevention() {
+            system_integration::test_dns_exfiltration_prevention::<$platform>();
+        }
     };
 }

--- a/tests/platform_test_macro.rs
+++ b/tests/platform_test_macro.rs
@@ -94,5 +94,10 @@ macro_rules! platform_tests {
         fn test_public_dns_blocked() {
             system_integration::test_public_dns_blocked::<$platform>();
         }
+
+        #[test]
+        fn test_non_http_tcp_services_blocked() {
+            system_integration::test_non_http_tcp_services_blocked::<$platform>();
+        }
     };
 }

--- a/tests/platform_test_macro.rs
+++ b/tests/platform_test_macro.rs
@@ -81,15 +81,18 @@ macro_rules! platform_tests {
         }
 
         #[test]
-        #[::serial_test::serial]
         fn test_jail_dns_resolution() {
             system_integration::test_jail_dns_resolution::<$platform>();
         }
 
         #[test]
-        #[::serial_test::serial]
         fn test_dns_exfiltration_prevention() {
             system_integration::test_dns_exfiltration_prevention::<$platform>();
+        }
+
+        #[test]
+        fn test_public_dns_blocked() {
+            system_integration::test_public_dns_blocked::<$platform>();
         }
     };
 }


### PR DESCRIPTION
## Summary

This PR addresses the DNS exfiltration vulnerability described in #53 by implementing a dummy DNS server that prevents data leakage through DNS queries.

## Problem

DNS lookups could be used to exfiltrate sensitive data (like `.env` contents) through subdomain queries to attacker-controlled DNS resolvers. For example, an attacker could encode stolen data in DNS queries like `stolen-data.attacker.com`.

## Solution

Implemented a minimal DNS server using the `simple-dns` crate that:
- Responds with `6.6.6.6` to ALL DNS queries
- Runs on the veth host IP (port 53) for proper namespace isolation  
- Redirects all DNS traffic from the namespace via nftables DNAT rules
- Prevents any DNS queries from leaving the jail

## Changes

- **Added `simple-dns` dependency**: Use well-maintained DNS parsing library
- **Added `src/jail/linux/dns.rs`**: Dummy DNS server using simple-dns crate
- **Updated nftables rules**: 
  - Redirect DNS traffic (UDP port 53) to local dummy server
  - Removed TCP port 53 support (DNS is UDP only)
  - Added explicit TCP drop rule for consistency
- **Modified namespace DNS config**: Point `/etc/resolv.conf` to veth host IP
- **Enhanced tests**: 
  - Verify DNS returns dummy IP and prevents exfiltration
  - Test blocking of public DNS servers (1.1.1.1)
  - Test blocking of non-HTTP TCP services (SSH)
- **Updated README**: Added DNS exfiltration protection section with sequence diagram

## Security Benefits

- ✅ Prevents DNS exfiltration attacks
- ✅ Blocks access to public DNS servers (1.1.1.1, 8.8.8.8)
- ✅ Blocks non-HTTP TCP services (SSH, etc.)
- ✅ No external DNS queries can escape the jail
- ✅ HTTP/HTTPS traffic still works (proxy uses Host header/SNI, not DNS)
- ✅ Simple and robust - same response for all queries

## Testing

- Updated `test_jail_dns_resolution` to verify dummy IP (6.6.6.6) is returned
- Added `test_dns_exfiltration_prevention` to test attack prevention  
- Added `test_public_dns_blocked` to verify 1.1.1.1 access blocked
- Added `test_non_http_tcp_services_blocked` to verify SSH blocking
- All existing tests pass

Fixes #53

## Test Plan

- [x] Build succeeds (`cargo build --profile fast`)
- [x] Clippy passes (`cargo clippy --all-targets -- -D warnings`)
- [x] Code formatted (`cargo fmt`)
- [x] Linux integration tests pass (requires Linux environment)
- [x] Verify DNS queries return 6.6.6.6 in jail
- [x] Verify public DNS servers are blocked
- [x] Verify non-HTTP TCP services are blocked
- [x] Verify HTTP/HTTPS traffic still works through proxy
- [x] All CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)