### PR TITLE
feat: implement transparent DNS redirect in strong jails

### DIFF
--- a/src/jail/mod.rs
+++ b/src/jail/mod.rs
@@ -75,6 +75,9 @@ pub struct JailConfig {
     /// Port for HTTPS proxy
     pub https_proxy_port: u16,
 
+    /// Port for DNS proxy (transparent redirect)
+    pub dns_proxy_port: u16,
+
     /// Unique identifier for this jail instance
     pub jail_id: String,
 
@@ -98,6 +101,7 @@ impl JailConfig {
         Self {
             http_proxy_port: 8040,
             https_proxy_port: 8043,
+            dns_proxy_port: 8053,
             jail_id,
             enable_heartbeat: true,
             heartbeat_interval_secs: 1,


### PR DESCRIPTION
## Summary
- Implement transparent DNS interception using nftables DNAT rules
- Remove all resolv.conf manipulation logic for a cleaner, more reliable approach
- Add configurable DNS proxy port to support the transparent redirect

## Background

Previously, httpjail modified `/etc/resolv.conf` in network namespaces to point DNS queries to our dummy DNS server. This approach had several limitations:
- Complex logic to handle different DNS configurations
- Required bind mounts and file system manipulation
- Could fail in certain environments

## Changes

### 1. Transparent DNS Redirect via nftables
- Added DNAT rules to redirect all UDP port 53 traffic to our DNS proxy
- Works identically to how we handle HTTP (port 80) and HTTPS (port 443) traffic
- DNS queries are intercepted regardless of the nameserver configuration

### 2. Configuration Updates
- Added `dns_proxy_port` field to `JailConfig` (default: 8053)
- DNS server now listens on the configurable proxy port instead of hardcoded port 53

### 3. Simplified DNS Handling
- Removed `fix_systemd_resolved_dns()` complexity - no longer modifies resolv.conf
- Simplified `ensure_namespace_dns()` - no action needed with transparent redirect
- Removed all temporary file creation and bind mount logic

### 4. nftables Rules
```nft
# In namespace (DNAT redirect)
udp dport 53 dnat to {host_ip}:{dns_proxy_port}

# On host (accept redirected traffic)
iifname "{veth_host}" udp dport {dns_proxy_port} accept
```

## Benefits

1. **True transparency**: Applications don't need any DNS configuration
2. **Universal compatibility**: Works with any resolver (8.8.8.8, 127.0.0.53, etc.)
3. **Simpler code**: ~130 lines removed, cleaner implementation
4. **More reliable**: No file system tricks or bind mounts required
5. **Consistent approach**: Uses same DNAT mechanism as HTTP/HTTPS

## Testing

The implementation avoids localhost redirect issues by using the veth pair's host-side IP (e.g., 10.0.x.1) for DNAT targets, not 127.0.0.1.

### Test Plan
- [ ] Verify DNS queries work with default system resolv.conf
- [ ] Test with various nameserver configurations (8.8.8.8, 127.0.0.53, etc.)
- [ ] Confirm DNS server receives redirected traffic on proxy port
- [ ] Validate existing HTTP/HTTPS functionality still works
- [ ] Run integration tests on Linux

## Notes

- This is Linux-specific (strong jail mode with network namespaces)
- macOS continues to use weak mode without network isolation
- The test script `test_dns_transparent.sh` was created for manual testing but not committed

🤖 Generated with [Claude Code](https://claude.ai/code)