### PR TITLE
Add SECURITY.md with security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+### Where to Report
+
+**Most security issues** should be reported directly on our [issue tracker](https://github.com/coder/httpjail/issues). Given the early stage of this tool, we encourage clear and public disclosure to help the community stay informed and protected.
+
+**Particularly sensitive issues** that could lead to immediate exploitation should be reported privately to: `security@coder.com`
+
+### Disclosure Preference
+
+Due to the tool's current maturity level, we prefer:
+- **Early disclosure** - Report issues as soon as they're discovered
+- **Clear communication** - Provide detailed reproduction steps and impact assessment  
+- **Public transparency** - Use the issue tracker for most reports
+
+As the project matures, we will implement more formal security disclosure processes, including coordinated disclosure timelines and security advisories.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Most security issues** should be reported directly on our [issue tracker](https://github.com/coder/httpjail/issues). Given the early stage of this tool, we encourage clear and public disclosure to help the community stay informed and protected.
 
-**Particularly sensitive issues** that could lead to immediate exploitation should be reported privately to: `security@coder.com`
+**Particularly sensitive issues** (e.g. those that could lead to arbitrary code execution on the host) should be reported privately to: `security@coder.com`
 
 ### Disclosure Preference
 


### PR DESCRIPTION
## Summary
- Adds SECURITY.md file to establish clear security reporting guidelines
- Directs most security issues to the public issue tracker for transparency
- Reserves security@coder.com for particularly sensitive vulnerabilities

## Rationale
Given the project's current maturity level, early and public disclosure is preferred to keep the community informed. As the project matures, more formal security processes can be evaluated.

## Test plan
- [x] Review that SECURITY.md is properly formatted
- [x] Verify links are correct
- [x] Confirm security email address is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)