### PR TITLE
docs: add test parallelism guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,16 @@ cargo test
 
 This ensures fast feedback during development and prevents CI timeouts.
 
+### Test Parallelism
+
+**Integration tests should run in parallel by default.** The jails are designed to be independent from each other, so the test suite should leverage good parallelism. Tests should only be marked as serial (`#[serial]`) when there's a specific global resource that would be contended, such as:
+
+- Global system settings that affect all processes
+- Shared network ports or interfaces
+- System-wide firewall rules that can't be isolated
+
+Each jail operates in its own network namespace (on Linux) or with its own proxy port, so most tests can safely run concurrently. This significantly reduces total test runtime.
+
 ## Cargo Cache
 
 Occasionally you will encounter permissions issues due to running the tests under sudo. In these cases,


### PR DESCRIPTION
## Summary
- Add documentation about test parallelism requirements
- Clarify when tests should be marked as serial vs parallel
- Explain that jails are designed to be independent and support concurrent testing

## Details
This PR adds a new "Test Parallelism" section to CLAUDE.md that documents:

1. Integration tests should run in parallel by default since jails operate independently
2. Tests should only be marked serial (`#[serial]`) when there's a specific global resource that would be contended
3. Examples of when serial might be needed:
   - Global system settings that affect all processes
   - Shared network ports or interfaces
   - System-wide firewall rules that can't be isolated
4. The rationale that each jail operates in isolation (network namespaces on Linux, separate proxy ports)

This guidance helps ensure the test suite runs efficiently by leveraging the independence of jail instances.

🤖 Generated with [Claude Code](https://claude.ai/code)