### PR TITLE
test: replace flaky httpbin.org with reliable Cloudflare endpoint

### DIFF
--- a/tests/weak_integration.rs
+++ b/tests/weak_integration.rs
@@ -295,47 +295,51 @@ fn test_server_mode() {
 fn test_host_header_security() {
     use std::process::Command;
 
-    // Define the same curl command that attempts to set a mismatched Host header
+    // Test with Cloudflare's trace endpoint that clearly shows the Host header
     let curl_args = vec![
         "-s",
         "-H",
         "Host: evil.com",
         "--max-time",
         "3",
-        "http://httpbin.org/headers",
+        "http://www.cloudflare.com/cdn-cgi/trace",
     ];
 
-    // Test 1: Direct curl execution (without httpjail) - shows the vulnerability
+    // Test 1: Direct curl execution (without httpjail) - Cloudflare blocks mismatched Host
     let direct_result = Command::new("curl")
         .args(&curl_args)
         .output()
         .expect("Failed to execute curl directly");
 
     let direct_stdout = String::from_utf8_lossy(&direct_result.stdout);
+    // Cloudflare returns an error code (1034) for mismatched Host headers
     assert!(
-        direct_stdout.contains("\"Host\": \"evil.com\""),
-        "Direct curl should pass through the evil.com Host header unchanged"
+        direct_stdout.contains("error code: 1034"),
+        "Direct curl with mismatched Host header should be blocked by Cloudflare with error 1034 (got: {})",
+        direct_stdout
     );
 
-    // Test 2: Same curl command through httpjail - shows the fix
+    // Test 2: Same curl command through httpjail - should correct the Host header
     let httpjail_result = HttpjailCommand::new()
         .weak()
         .js("true") // Allow all requests
-        .command(vec!["curl"].into_iter().chain(curl_args).collect())
+        .command(vec!["curl"].into_iter().chain(curl_args.clone()).collect())
         .execute();
 
     assert!(httpjail_result.is_ok(), "Httpjail request should complete");
     let (exit_code, stdout, _) = httpjail_result.unwrap();
     assert_eq!(exit_code, 0, "Httpjail request should succeed");
 
-    // Httpjail should have corrected the Host header to match the URI
+    // Httpjail should have corrected the Host header, allowing the request to succeed
     assert!(
-        stdout.contains("\"Host\": \"httpbin.org\""),
-        "Httpjail should correct the Host header to httpbin.org"
+        stdout.contains("h=www.cloudflare.com"),
+        "Httpjail should correct the Host header to www.cloudflare.com, allowing the request (got: {})",
+        stdout
     );
     assert!(
-        !stdout.contains("\"Host\": \"evil.com\""),
-        "Httpjail should not pass through the evil.com Host header"
+        !stdout.contains("error code: 1034"),
+        "Httpjail-corrected request should not be blocked by Cloudflare (got: {})",
+        stdout
     );
 
     // This demonstrates that httpjail prevents the Host header bypass attack


### PR DESCRIPTION
## Summary
- Replace httpbin.org in host header security test with Cloudflare's cdn-cgi/trace endpoint
- Eliminates test flakiness while maintaining comprehensive security verification

## Why this change?
The host header security tests were experiencing flakiness due to httpbin.org availability issues. This change replaces it with Cloudflare's trace endpoint which is:
- Always available as part of Cloudflare's infrastructure  
- Provides clear host header information in responses
- Reliably blocks mismatched Host headers with error code 1034

## Test plan
- [x] Run `cargo test test_host_header_security --test weak_integration`
- [x] Verify test passes consistently without flakiness
- [x] Confirm all weak integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)