### PR TITLE
docs: Fix Line Processor response format documentation

### DIFF
--- a/docs/guide/rule-engines/index.md
+++ b/docs/guide/rule-engines/index.md
@@ -47,7 +47,7 @@ httpjail --js "r.host === 'github.com'" -- command
 import sys, json
 for line in sys.stdin:
     req = json.loads(line)
-    print("allow" if req["host"] == "github.com" else "deny")
+    print("true" if req["host"] == "github.com" else "false")
 ```
 
 ### Complex Logic
@@ -90,9 +90,9 @@ for line in sys.stdin:
 
     if host_limit["count"] < 100:  # 100 requests per minute
         host_limit["count"] += 1
-        print("allow")
+        print("true")
     else:
-        print("deny")
+        print("false")
     sys.stdout.flush()
 ```
 


### PR DESCRIPTION
Fixes inaccurate documentation about Line Processor response formats.

The Line Processor does NOT accept simple text "allow" or "deny". Based on the implementation in `src/rules/common.rs:46-76`, it accepts:
- `"true"` / `"false"` (boolean strings)
- JSON objects with allow/deny_message  
- Any other text is treated as deny with that text as the message

This PR updates all examples to use the correct format.