### PR TITLE
docs: Add IIFE pattern for return statements in JS rules

### DIFF
--- a/docs/guide/rule-engines/javascript.md
+++ b/docs/guide/rule-engines/javascript.md
@@ -62,6 +62,24 @@ r.host === 'facebook.com' ? {deny_message: 'Social media blocked'} : true
 ({allow: {max_tx_bytes: 1024}})
 ```
 
+## Using Return Statements
+
+JavaScript rules don't allow naked `return` statements. To use returns, wrap your code in an IIFE:
+
+```javascript
+(function() {
+  if (r.host === 'github.com') {
+    return true;
+  }
+  
+  if (r.host.match(/facebook|twitter/)) {
+    return {deny_message: "Blocked"};
+  }
+  
+  return false;
+})();
+```
+
 ## Common Patterns
 
 ### Domain Allowlisting


### PR DESCRIPTION
Addresses #87 by documenting how to use return statements in JavaScript rules via the IIFE pattern.

## Changes
- Added "Using Return Statements" section to JavaScript rules documentation
- Shows simple IIFE example with return statements

## Testing
- Verified IIFE pattern works with manual testing
- All existing tests pass
- No code changes, documentation only

This keeps the implementation simple while giving users the capability they requested.