### PR TITLE
Implement automatic JavaScript file reloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1001,7 @@ name = "httpjail"
 version = "0.5.1"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "assert_cmd",
  "async-trait",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simple-dns = "0.7"
 tempfile = "3.8"
+arc-swap = "1.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Or download a pre-built binary from the [releases page](https://github.com/coder
 # Allow only requests to github.com (JS)
 httpjail --js "r.host === 'github.com'" -- your-app
 
-# Load JS from a file
+# Load JS from a file (auto-reloads on file changes)
 echo "/^api\\.example\\.com$/.test(r.host) && r.method === 'GET'" > rules.js
 httpjail --js-file rules.js -- curl https://api.example.com/health
+# File changes are detected and reloaded automatically on each request
 
 # Log requests to a file
 httpjail --request-log requests.log --js "true" -- npm install

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -16,6 +16,7 @@ httpjail follows a simple configuration hierarchy:
 Choose how requests are evaluated:
 
 - **JavaScript** (`--js` or `--js-file`) - Fast, sandboxed evaluation
+  - Files specified with `--js-file` are automatically reloaded when changed
 - **Shell Script** (`--sh`) - System integration, external tools
 - **Line Processor** (`--proc`) - Stateful, streaming evaluation
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -80,6 +80,8 @@ isAllowed && r.method !== 'DELETE';
 httpjail --js-file rules.js -- npm install
 ```
 
+> **Tip:** Rules files are automatically reloaded when they change - perfect for development and debugging! Just edit `rules.js` and the changes take effect on the next request.
+
 ### Request Logging
 
 Monitor what requests are being made:

--- a/docs/guide/rule-engines/javascript.md
+++ b/docs/guide/rule-engines/javascript.md
@@ -41,6 +41,28 @@ allowedHosts.includes(r.host);
 httpjail --js-file rules.js -- command
 ```
 
+#### Automatic File Reloading
+
+When using `--js-file`, httpjail automatically detects and reloads the file when it changes. This is especially useful during development and debugging:
+
+```bash
+# Start with initial rules
+echo "r.host === 'example.com'" > rules.js
+httpjail --js-file rules.js -- your-app
+
+# In another terminal, update the rules (reloads automatically on next request)
+echo "r.host === 'github.com'" > rules.js
+```
+
+**How it works:**
+- File modification time (mtime) is checked on each request
+- If the file has changed, it's reloaded and validated
+- Invalid JavaScript is rejected and existing rules are kept
+- Reload happens atomically without interrupting request processing
+- Zero overhead when the file hasn't changed
+
+**Note:** File watching is only active when using `--js-file`. Inline rules (`--js`) do not reload.
+
 ## Response Format
 
 {{#include ../../includes/response-format-table.md}}

--- a/src/main.rs
+++ b/src/main.rs
@@ -429,7 +429,8 @@ async fn main() -> Result<()> {
         info!("Using V8 JavaScript rule evaluation from file: {}", js_file);
         let code = std::fs::read_to_string(js_file)
             .with_context(|| format!("Failed to read JS file: {}", js_file))?;
-        let js_engine = match V8JsRuleEngine::new(code) {
+        let js_file_path = std::path::PathBuf::from(js_file);
+        let js_engine = match V8JsRuleEngine::new_with_file(code, Some(js_file_path)) {
             Ok(engine) => Box::new(engine),
             Err(e) => {
                 eprintln!("Failed to create V8 JavaScript engine: {}", e);

--- a/tests/js_file_reload.rs
+++ b/tests/js_file_reload.rs
@@ -1,0 +1,110 @@
+use httpjail::rules::RuleEngineTrait;
+use httpjail::rules::v8_js::V8JsRuleEngine;
+use hyper::Method;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::NamedTempFile;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_js_file_reload() {
+    // Create a temporary JS file and persist it to avoid early deletion
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let (file, path) = temp_file.into_parts();
+    let file_path = PathBuf::from(&path);
+    drop(file); // Close the file handle
+
+    // Write initial rule (allow all requests)
+    fs::write(&file_path, "true").expect("Failed to write initial rule");
+
+    // Create engine with file watching
+    let code = fs::read_to_string(&file_path).expect("Failed to read file");
+    let engine = V8JsRuleEngine::new_with_file(code, Some(file_path.clone()))
+        .expect("Failed to create engine");
+
+    // Test initial rule (should allow)
+    let result = engine
+        .evaluate(Method::GET, "https://example.com", "127.0.0.1")
+        .await;
+    assert!(matches!(result.action, httpjail::rules::Action::Allow));
+
+    // Update the JS file (deny all requests)
+    fs::write(&file_path, "false").expect("Failed to write updated rule");
+
+    // Reload happens on next evaluate call - no waiting needed
+
+    // Test updated rule (should deny)
+    let result = engine
+        .evaluate(Method::GET, "https://example.com", "127.0.0.1")
+        .await;
+    assert!(matches!(result.action, httpjail::rules::Action::Deny));
+
+    // Update again with a more complex rule
+    fs::write(&file_path, "r.host === 'allowed.com'").expect("Failed to write complex rule");
+
+    // Reload happens on next evaluate call - no waiting needed
+
+    // Test with allowed host
+    let result = engine
+        .evaluate(Method::GET, "https://allowed.com/path", "127.0.0.1")
+        .await;
+    assert!(matches!(result.action, httpjail::rules::Action::Allow));
+
+    // Test with denied host
+    let result = engine
+        .evaluate(Method::GET, "https://denied.com/path", "127.0.0.1")
+        .await;
+    assert!(matches!(result.action, httpjail::rules::Action::Deny));
+
+    // Clean up
+    let _ = fs::remove_file(&file_path);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_js_file_reload_syntax_error() {
+    // Create a temporary JS file and persist it
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let (file, path) = temp_file.into_parts();
+    let file_path = PathBuf::from(&path);
+    drop(file);
+
+    // Write initial valid rule
+    fs::write(&file_path, "true").expect("Failed to write initial rule");
+
+    // Create engine with file watching
+    let code = fs::read_to_string(&file_path).expect("Failed to read file");
+    let engine = V8JsRuleEngine::new_with_file(code, Some(file_path.clone()))
+        .expect("Failed to create engine");
+
+    // Test initial rule (should allow)
+    let result = engine
+        .evaluate(Method::GET, "https://example.com", "127.0.0.1")
+        .await;
+    assert!(matches!(result.action, httpjail::rules::Action::Allow));
+
+    // Update the JS file with syntax error
+    fs::write(&file_path, "this is not valid javascript {{[")
+        .expect("Failed to write invalid rule");
+
+    // Reload check happens on next evaluate call - no waiting needed
+
+    // Test that the old rule is still in effect (reload should have been rejected)
+    let result = engine
+        .evaluate(Method::GET, "https://example.com", "127.0.0.1")
+        .await;
+    assert!(matches!(result.action, httpjail::rules::Action::Allow));
+
+    // Clean up
+    let _ = fs::remove_file(&file_path);
+}
+
+#[tokio::test]
+async fn test_js_engine_without_file_path() {
+    // Create engine without file path (no file watching)
+    let engine = V8JsRuleEngine::new("true".to_string()).expect("Failed to create engine");
+
+    // Test that it works normally
+    let result = engine
+        .evaluate(Method::GET, "https://example.com", "127.0.0.1")
+        .await;
+    assert!(matches!(result.action, httpjail::rules::Action::Allow));
+}


### PR DESCRIPTION
Closes #88

## Overview

Implements automatic reloading of JavaScript rules when using `--js-file`. The file is checked for modifications on each request, and if changed, the code is validated and atomically reloaded.

## Implementation Approach

**On-demand mtime checking** (not background polling or inotify):
- File modification time checked on each request in `evaluate()` method
- When mtime changes: read file, validate JS, atomically update code
- No background tasks - simpler, testable, zero overhead when idle

**Key Design Decisions:**
1. **Lock-free reads with ArcSwap** - `ArcSwap<(String, Option<SystemTime>)>` for hot path performance
2. **Singleflight pattern** - Mutex-based double-check locking prevents concurrent reloads
3. **Validation before reload** - Invalid JS rejected, existing rules kept on error
4. **Atomic updates** - Code and mtime always consistent

## Code Refactoring

The `evaluate()` method was decomposed from 98 lines into focused helper methods:
- `check_and_reload_file()` - File monitoring and reload logic (48 lines)
- `load_js_code()` - Lock-free code loading (4 lines)
- `execute_js_blocking()` - V8 execution in blocking task (32 lines)
- `build_evaluation_result()` - Result construction (15 lines)

Also added comprehensive module and struct documentation.

## Testing

- ✅ 3 new integration tests in `tests/js_file_reload.rs`
- ✅ All 44 existing unit tests pass
- ✅ Clippy clean, properly formatted

## Documentation

Updated:
- README.md - File reload feature
- docs/guide/quick-start.md - Usage examples
- docs/guide/configuration.md - `--js-file` flag documentation
- docs/guide/rule-engines/javascript.md - Detailed behavior

## Dependencies

Added `arc-swap = "1.7"` to Cargo.toml for lock-free atomic updates.