### PR TITLE
ci: fix cargo caching in docs build and update deprecated macOS runner

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}
+
       - name: Build documentation
         run: ./scripts/mdbook.sh build
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             os: ubuntu-latest-16-cores
             name: linux-aarch64
           - target: x86_64-apple-darwin
-            os: macos-13-large
+            os: macos-latest-large
             name: macos-x86_64
           - target: aarch64-apple-darwin
             os: macos-14-xlarge


### PR DESCRIPTION
## Changes

### 1. Fixed Cargo Caching in docs.yml
- Added `Swatinem/rust-cache@v2` action to the documentation build workflow
- Properly caches cargo dependencies, build artifacts, and registry index
- Should significantly speed up docs build on subsequent runs

### 2. Updated Deprecated macOS Runner in release.yml
- Changed from `macos-13-large` to `macos-latest-large` for x86_64-apple-darwin builds
- GitHub has deprecated macOS 13 runners; this ensures we use a supported runner version

## Testing
- Validated YAML syntax for all modified workflow files
- Both changes follow the same pattern used in other workflows (tests.yml, benchmark.yml, etc.)